### PR TITLE
Changing backend image

### DIFF
--- a/tutorial/demo-app.yaml
+++ b/tutorial/demo-app.yaml
@@ -44,7 +44,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:1.2
         imagePullPolicy: IfNotPresent
 ---
 apiVersion: v1


### PR DESCRIPTION
The docker hub where the backend image was being pulled from is deprecated. The new official repo is the quay.io repo.
The link went from "docker.io/cilium/json-mock" to "quay.io/cilium/json-mock".